### PR TITLE
Fix Korean in english page

### DIFF
--- a/src/locale/about/en.js
+++ b/src/locale/about/en.js
@@ -1,5 +1,5 @@
 export default {
   about: {
-    title: '이 페이지는 정보 페이지입니다.',
+    title: 'This is about page.',
   },
 };


### PR DESCRIPTION
## Description

In locale, the English part of about section is using Korean instead of English,